### PR TITLE
Add boa recipe with CI workflow to build+publish on releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   run:
     runs-on: ${{ matrix.os }}
+    environment: boa
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +39,6 @@ jobs:
       - name: Publish
         shell: bash -l {0}
         run: |
-          anaconda upload --user $USER ./build/*/*.tar.bz2
+          anaconda upload --user ${{ vars.ANACONDA_USER }} ./build/*/*.tar.bz2
         env:
-          USER: ${{ vars.ANACONDA_CHANNEL }}
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,47 @@
+name: Build
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  # ANACONDA_CHANNEL: svenrodriguez
+  ANACONDA_CHANNEL: ipsl
+
+jobs:
+  run:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python: # use quotes to avoid float casting (3.10 => 3.1)
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+        os:
+          - ubuntu-latest
+          - macos-latest
+          # - windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install mamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: recipe/env.yml
+      - name: Build
+        shell: bash -l {0}
+        run: |
+          mkdir build
+          boa build recipe \
+            --output-folder ./build \
+            --variant-config-files recipe/variants.yaml \
+            --python ${{ matrix.python }}
+      - name: Publish
+        shell: bash -l {0}
+        run: |
+          anaconda upload --user $ANACONDA_CHANNEL ./build/*/*.tar.bz2
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,10 +5,6 @@ on:
     types:
       - published
 
-env:
-  # ANACONDA_CHANNEL: svenrodriguez
-  ANACONDA_CHANNEL: ipsl
-
 jobs:
   run:
     runs-on: ${{ matrix.os }}
@@ -42,6 +38,7 @@ jobs:
       - name: Publish
         shell: bash -l {0}
         run: |
-          anaconda upload --user $ANACONDA_CHANNEL ./build/*/*.tar.bz2
+          anaconda upload --user $USER ./build/*/*.tar.bz2
         env:
+          USER: ${{ vars.ANACONDA_CHANNEL }}
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}

--- a/recipe/env.yml
+++ b/recipe/env.yml
@@ -1,0 +1,10 @@
+name: build
+channels:
+  - conda-forge
+dependencies:
+  - python
+  - pip
+  - mamba
+  - libmambapy
+  - boa = 0.15.1
+  - anaconda-client

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,0 +1,48 @@
+context:
+  refname: "{{ environ['GITHUB_REF_NAME'] }}"
+
+package:
+  name: sbck
+  version: "{{ refname }}"
+
+source:
+  - path: ..
+  # - git_url: https://github.com/yrobink/SBCK-python.git
+  #   git_rev: 4f2f165f18650fffe64ac0db45e7f30891dc0b77
+  #   git_depth: 1
+
+build:
+  number: 0
+  script: python -m pip install --ignore-installed .
+  include_recipe: false
+
+requirements:
+  # build:
+  #   - "{{ compiler('cxx') }}"
+  #   - "python {{ python }}"
+  #   - pybind11 >=2.2
+  #   - eigen >=3.4.0
+
+  # build:
+  #   - python
+  #   - setuptools
+  #   - pybind11 >=2.2
+  #   - eigen >=3.4.0
+
+  host:
+    - python
+    - setuptools
+    - pybind11 >=2.2
+    - eigen >=3.4.0
+
+  run:
+    - python
+    - numpy
+    - scipy
+    - matplotlib
+    - pybind11 >=2.2
+    - pot >=0.9.0
+
+test:
+  imports:
+    - SBCK

--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -1,0 +1,4 @@
+cxx_compiler:
+  - gxx                           # [linux]
+  - clangxx                       # [osx]
+  # - vs2017                        # [win]


### PR DESCRIPTION
# Description

This PR adds a boa recipe that correctly builds `SBCK` to distribute it with the c++ files already compiled against a python ABI version.

It also includes a Github workflow that builds and publishes the matrix of `[OS, python version]` packages to a configurable anaconda channel.


## Example

The outcome of this pipeline is a bunch a conda files, each linked to one OS and one python version, and published on the chosen anaconda channel.

For example, on my fork I used my own channel `svenrodriguez`, and an API token created for the occasion:
Release that triggered the pipeline: https://github.com/svenrdz/SBCK-python/releases
Pipeline logs: https://github.com/svenrdz/SBCK-python/actions/runs/7490690429
Published files: https://anaconda.org/svenrodriguez/sbck/files#


## CI workflow details

The github workflow defines a simple sequential job:
1. **install conda environment for building sbck**, this uses `boa` as it was more convenient to iterate locally, the recipe can be adapted easily if `conda-build` should eventually be used for some reason, they only differ by a few yaml fields.
2. **build** the package 
3. publish it to a configured anaconda channel

A matrix of `[OS, python version]` is written in the Github workflow file. Python versions goes from `3.8` to `3.12`, and OSes are `ubuntu-latest` and `macos-latest` (Windows never worked in previous tests so I did not include it).
The job described above is then ran once for each combination.

Github actions' environment feature is used to configure on which conda channel the package is published.
Read next section for setup details.


## Initial setup

For this to work correctly, an initial setup must be done on the Github settings of this repo:

- Create an environment that will hold variables and secrets for the workflow: 
  * From https://github.com/yrobink/SBCK-python go to **Settings** -> **Code and automation** (left panel) -> **Environments** -> **New environment**
  * The new environment's name should match the workflow's hardcoded environment name. I arbitrarily set it to `boa` but it can be changed if needed.
- Add required variables and secrets:
  * In the `boa` environment, create a **variable** named `ANACONDA_USER` and set it to the **channel** on which the built files will be published. You must have **write** permission on the select channel, in case it is not the same namespace as your own anaconda account.
  * In the `boa` environment, create a **secret** named `ANACONDA_API_TOKEN` and paste an API token created from your anaconda account. It must have the `api:write` scope to work properly. You can create a new token from this webpage, after replacing `<username>` with your own: `https://anaconda.org/<username>/settings/access`

From there, a new conda package will be built and published on the selected channel, each time a new Release is published, using Github's release feature. I strongly recommend creating a corresponding tag from the "New release" page, which matches the release's version, since this will be used to determine the conda package's version.


## Maintenance

For future versions, in case the set of dependencies evolves, I recommend updating the recipe accordingly. The recipe can be tested by building with the following set of commands:

```shell
cd path/to/my/repo

# skip this line if the build environment already exists
mamba env create --name sbck_build_env --file recipe/env.yml

# update these to whatever the values should be
PYTHON_VERSION=3.9
SBCK_VERSION=1.4.0

mamba activate sbck_build_env
GITHUB_REF_NAME=$SBCK_VERSION boa build recipe \
  --output-folder ./build \
  --variant-config-files recipe/variants.yaml \
  --python $PYTHON_VERSION
```

The last step of the build process tests whether `import SBCK` works in a temporary environment that only has the build result. It is not the best success metric, but since there are no tests in SBCK, it is the best we can do for now. 

To delete all build artifacts, simply run:
```shell
rm -fr ./build
```