### PR TITLE
Allow providing the path to Eigen using environment variables.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ R/*.tar.gz
 R/*.Rcheck
 R/.Rd2pdf*
 R/*.pdf
-
 .idea/
+*.pyd

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ R/*.tar.gz
 R/*.Rcheck
 R/.Rd2pdf*
 R/*.pdf
+
+.idea/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/eigen"]
+	path = external/eigen
+	url = https://gitlab.com/libeigen/eigen.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel", "pybind11"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ import sys
 import sysconfig
 import subprocess
 import tempfile
-import shutil
+import uuid
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 import setuptools
@@ -132,8 +132,8 @@ class BuildExt(build_ext):##{{{
 
 	def initialize_options(self):
 		temp_dir = tempfile.gettempdir()
-		random_suffix = str( os.getpid() ) + str( os.getuid() )
-		self.build_temp = os.path.join(temp_dir, 'sbck_build_temp_' + random_suffix)
+		random_suffix = str(uuid.uuid4())  # More robust and unique than using pid or uid
+		self.build_temp = os.path.join(temp_dir, f'sbck_build_temp_{random_suffix}')
 		super().initialize_options()
 
 	def run(self):

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ import os
 import sys
 import sysconfig
 import subprocess
+import tempfile
+import shutil
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 import setuptools
@@ -127,6 +129,14 @@ class BuildExt(build_ext):##{{{
 	
 	if sys.platform == 'darwin':
 		c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
+
+	def initialize_options(self):
+		if os.environ.get("SBCK_TEMP_DIR") is not None:
+			self.build_temp = os.environ.get("SBCK_TEMP_DIR")
+		else:
+			# Set the build_temp directory to the system's temporary directory
+			self.build_temp = tempfile.mkdtemp(prefix='sbck_build_')
+		super().initialize_options()
 
 	def run(self):
 		# Ensure the Eigen submodule is initialized and updated

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ from pathlib import Path
 ## User Eigen path ##
 #####################
 
-eigen_usr_include = ""
+eigen_usr_include = os.environ.get('EIGEN_PATH', '')
 
 i_eigen = -1
 for i,arg in enumerate(sys.argv):

--- a/setup.py
+++ b/setup.py
@@ -231,7 +231,6 @@ setup(
 		"Programming Language :: Python :: 3.10",
 		"Topic :: Scientific/Engineering :: Mathematics"
 	],
-	build_requires   = ["pybind11>=2.2"],
 	ext_modules      = ext_modules,
 	install_requires = ["numpy" , "scipy" , "matplotlib" , "pybind11>=2.2" , "pot>=0.9.0"],
 	cmdclass         = {'build_ext': BuildExt},

--- a/setup.py
+++ b/setup.py
@@ -131,11 +131,9 @@ class BuildExt(build_ext):##{{{
 		c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
 
 	def initialize_options(self):
-		if os.environ.get("SBCK_TEMP_DIR") is not None:
-			self.build_temp = os.environ.get("SBCK_TEMP_DIR")
-		else:
-			# Set the build_temp directory to the system's temporary directory
-			self.build_temp = tempfile.mkdtemp(prefix='sbck_build_')
+		temp_dir = tempfile.gettempdir()
+		random_suffix = str( os.getpid() ) + str( os.getuid() )
+		self.build_temp = os.path.join(temp_dir, 'sbck_build_temp_' + random_suffix)
 		super().initialize_options()
 
 	def run(self):

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ class BuildExt(build_ext):##{{{
 		# Ensure the Eigen submodule is initialized and updated
 		if not os.path.exists("external/eigen"):
 			print("Updating Eigen submodule...")
-			subprocess.run(["git", "submodule", "update", "--init", "--recursive"], check=True)
+			subprocess.run(["git", "submodule", "update", "--init", "--recursive", "--depth", "1"], check=True)
 
 		# Call the original run method to proceed with the build
 		super().run()


### PR DESCRIPTION
Using the EIGEN_PATH environment variable as an additional way to provide the path to Eigen helps integrate the SBCK package into other packages, mainly on Windows. The option will be overridden when a path to Eigen is provided through the command line.